### PR TITLE
Fix invalid log format

### DIFF
--- a/pkg/controller/clusteringress/clusteringress_controller.go
+++ b/pkg/controller/clusteringress/clusteringress_controller.go
@@ -191,7 +191,7 @@ func (r *ReconcileClusterIngress) reconcileRoute(ctx context.Context, ci *networ
 	if err != nil && errors.IsNotFound(err) {
 		err = r.client.Create(ctx, desired)
 		if err != nil {
-			logger.Errorw("Failed to create OpenShift Route %q in namespace %q", desired.Name, desired.Namespace, err)
+			logger.Errorf("Failed to create OpenShift Route %q in namespace %q: %v", desired.Name, desired.Namespace, err)
 			return err
 		}
 		logger.Infof("Created OpenShift Route %q in namespace %q", desired.Name, desired.Namespace)
@@ -203,7 +203,7 @@ func (r *ReconcileClusterIngress) reconcileRoute(ctx context.Context, ci *networ
 		existing.Spec = desired.Spec
 		err = r.client.Update(ctx, existing)
 		if err != nil {
-			logger.Errorw("Failed to update OpenShift Route %q in namespace %q", desired.Name, desired.Namespace, err)
+			logger.Errorf("Failed to update OpenShift Route %q in namespace %q: %v", desired.Name, desired.Namespace, err)
 			return err
 		}
 	}


### PR DESCRIPTION
This patch makes a small fix for invalid usage of `Errorw`.
Currently log message outputs raw `%q` as `Failed to create OpenShift
Route %q in namespace %q`.

* c.f. log message in knative-openshift-ingress pod
```
{"level":"error","ts":1559714571.921199,"logger":"fallback","caller":"clusteringress/clusteringress_controller.go:194","msg":"Failed to create OpenShift Route %q in namespace %q","route-862f7d18-8757-11e9-bcf1-664f163f5f0f-0":"istio-system", ...snip...
```