### PR TITLE
Expose metrics via kubernetes service

### DIFF
--- a/deploy/release.yaml
+++ b/deploy/release.yaml
@@ -14,6 +14,7 @@ rules:
   - ""
   resources:
   - pods
+  - services
   - events
   - configmaps
   verbs:
@@ -55,6 +56,13 @@ rules:
   - routes/finalizers
   verbs:
   - "*"
+- apiGroups:
+  - serving.knative.dev
+  resources:
+  - knativeservings
+  - knativeservings/finalizers
+  verbs:
+  - '*'
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
Currently operator fails to create service to expose metrics via
service.

This patch adds a few permission to `knative-openshift-ingress`
clusterrole.

BEFORE:
```
$ oc logs knative-openshift-ingress-65876c9b87-m228b
 ...
{"level":"info","ts":1559797525.143741,"logger":"cmd","msg":"failed to initialize service object for metrics: knativeservings.serving.knative.dev \"knative-serving\" is forbidden: User \"system:serviceaccount:default:knative-openshift-ingress\" cannot get resource \"knativeservings\" in API group \"serving.knative.dev\" in the namespace \"default\""}
```

AFTER:

No error & you can access to `/metrics` via service.

```
$ oc get svc knative-openshift-ingress
NAME                        TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)    AGE
knative-openshift-ingress   ClusterIP   172.30.122.241   <none>        8383/TCP   59m
```