### PR TITLE
Introduce annotation to stop making route

### DIFF
--- a/pkg/controller/resources/route.go
+++ b/pkg/controller/resources/route.go
@@ -15,8 +15,8 @@ import (
 )
 
 const (
-	TimeoutAnnotation = "haproxy.router.openshift.io/timeout"
-	DisableRoute      = "serving.knative.dev/disableRoute"
+	TimeoutAnnotation      = "haproxy.router.openshift.io/timeout"
+	DisableRouteAnnotation = "serving.knative.openshift.io/disableRoute"
 )
 
 // MakeRoutes creates OpenShift Routes from a Knative Ingress
@@ -33,12 +33,12 @@ func MakeRoutes(ci networkingv1alpha1.IngressAccessor) ([]*routev1.Route, error)
 			parts := strings.Split(host, ".")
 			if len(parts) > 2 && parts[2] != "svc" {
 				route, err := makeRoute(ci, host, routeIndex, rule)
-				if route == nil && err == nil {
-					continue
-				}
 				routeIndex = routeIndex + 1
 				if err != nil {
 					return nil, err
+				}
+				if route == nil {
+					continue
 				}
 				routes = append(routes, route)
 			}
@@ -56,7 +56,7 @@ func makeRoute(ci networkingv1alpha1.IngressAccessor, host string, index int, ru
 	}
 
 	// Skip making route when the annotation is specified.
-	if _, ok := annotations[DisableRoute]; ok {
+	if _, ok := annotations[DisableRouteAnnotation]; ok {
 		return nil, nil
 	}
 

--- a/pkg/controller/resources/route_test.go
+++ b/pkg/controller/resources/route_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	routev1 "github.com/openshift/api/route/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/serving/pkg/apis/networking"
 	networkingv1alpha1 "knative.dev/serving/pkg/apis/networking/v1alpha1"
@@ -82,6 +83,16 @@ func TestMakeRouteForTimeout(t *testing.T) {
 		assert.Equal(t, "600s", routes[i].ObjectMeta.Annotations[TimeoutAnnotation])
 		assert.NotEqual(t, 10*time.Minute, routes[i].ObjectMeta.Annotations[TimeoutAnnotation])
 	}
+}
+
+func TestDisableRouteByAnnotation(t *testing.T) {
+	host := []string{"public.default.domainName", "local.default.domainName"}
+	ci := createClusterIngressObj("istio-ingressgateway.istio-system.svc.cluster.local", host)
+	ci.ObjectMeta.Annotations = map[string]string{DisableRoute: ""}
+
+	routes, err := MakeRoutes(ci)
+	assert.Equal(t, []*routev1.Route{}, routes)
+	assert.Nil(t, err)
 }
 
 func TestMakeRouteInvalidDomain(t *testing.T) {

--- a/pkg/controller/resources/route_test.go
+++ b/pkg/controller/resources/route_test.go
@@ -88,7 +88,7 @@ func TestMakeRouteForTimeout(t *testing.T) {
 func TestDisableRouteByAnnotation(t *testing.T) {
 	host := []string{"public.default.domainName", "local.default.domainName"}
 	ci := createClusterIngressObj("istio-ingressgateway.istio-system.svc.cluster.local", host)
-	ci.ObjectMeta.Annotations = map[string]string{DisableRoute: ""}
+	ci.ObjectMeta.Annotations = map[string]string{DisableRouteAnnotation: ""}
 
 	routes, err := MakeRoutes(ci)
 	assert.Equal(t, []*routev1.Route{}, routes)


### PR DESCRIPTION
This patch have two improvements:

* Let route take over annotations from ingress.
* Introduce `serving.knative.dev/disableRoute` to stop making routes

For first improvement, currently Routes do not take over the
anntatoins from ingress, so they misses some useful annotations such as
`knative.dev/creator` and `/lastModifier`.
For second improvement, knative-openshift-ingress always creates
routes. It means that users cannot use istio gateway easily and make it
difficult for troubleshooting and testing sometimes.

This patch addresses these problems.

Fixes https://jira.coreos.com/browse/SRVKS-156