### PR TITLE
Add passthrough TLS setting 

### DIFF
--- a/pkg/controller/resources/route.go
+++ b/pkg/controller/resources/route.go
@@ -125,7 +125,7 @@ func makeRoute(ci networkingv1alpha1.IngressAccessor, host string, index int, ru
 		Spec: routev1.RouteSpec{
 			Host: host,
 			Port: &routev1.RoutePort{
-				TargetPort: intstr.FromInt(80),
+				TargetPort: intstr.FromString("http"),
 			},
 			To: routev1.RouteTargetReference{
 				Kind: "Service",
@@ -137,7 +137,7 @@ func makeRoute(ci networkingv1alpha1.IngressAccessor, host string, index int, ru
 		switch strings.ToLower(terminationType) {
 		case "passthrough":
 			route.Spec.TLS = &routev1.TLSConfig{Termination: routev1.TLSTerminationPassthrough}
-			route.Spec.Port = &routev1.RoutePort{TargetPort: intstr.FromInt(443)}
+			route.Spec.Port = &routev1.RoutePort{TargetPort: intstr.FromString("https")}
 		default:
 			return nil, ErrNotSupportedTLSTermination
 		}

--- a/pkg/controller/resources/route_test.go
+++ b/pkg/controller/resources/route_test.go
@@ -129,19 +129,19 @@ func TestMakeSecuredRoute(t *testing.T) {
 		wantErr        error
 	}{
 		{
-			name:        "Simple Passthrough teramination",
+			name:        "Simple Passthrough termination",
 			annotations: map[string]string{TLSTerminationAnnotation: "passthrough"},
 			want: &routev1.TLSConfig{
 				Termination: routev1.TLSTerminationPassthrough,
 			},
-			wantTargetPort: intstr.FromInt(443),
+			wantTargetPort: intstr.FromString("https"),
 			wantErr:        nil,
 		},
 		{
-			name:           "Unsupported teramination",
+			name:           "Unsupported termination",
 			annotations:    map[string]string{TLSTerminationAnnotation: "edge"},
 			want:           nil,
-			wantTargetPort: intstr.FromInt(443),
+			wantTargetPort: intstr.FromString("https"),
 			wantErr:        ErrNotSupportedTLSTermination,
 		},
 	}


### PR DESCRIPTION
This patch introduces an annotation
`serving.knative.openshift.io/tlsTermination` to support passthrough
TLS termination.

Note, as following example also mentions, Knative does not support
`passthrough`, so we need to configure TLS on Knative side.

### Example usage:

#### 1. Set annotation to the KSVC.

```
$ oc annotate --overwrite ksvc ${YOUR_KSVC_NAME}  \
                serving.knative.openshift.io/tlsTermination=passthrough
```

#### 2. Delete `clusteringresses` or `ingresses` to rfresh `routes`.

```
$ oc delete clusteringresses.networking.internal.knative.dev \
                         route-bcb84733-b8ff-11e9-b31e-06d0657ebc6e
```
NOTE: v0.8.0 or later, you need to delete `ingresses.networking.internal.knative.dev` instead of `clusteringresses`.

#### 3. Confirm routes has passthrough now.

```
$ oc get routes.route.openshift.io -n istio-system
NAME                                           HOST/PORT                                           PATH   SERVICES               PORT   TERMINATION   WILDCARD
route-8bdf7b9d-b8ee-11e9-9e59-02894d78aa54-0   helloworld-go.default.apps.example.com          istio-ingressgateway   443    passthrough   None
```

#### 4. Setup Knative's TLS e.g. AutoTLS

Now, we can access to the service with TLS.