### PR TITLE
Change route name to recognizable name

### DIFF
--- a/pkg/controller/clusteringress/clusteringress_controller_test.go
+++ b/pkg/controller/clusteringress/clusteringress_controller_test.go
@@ -27,8 +27,10 @@ func TestClusterIngressController(t *testing.T) {
 	logf.SetLogger(logf.ZapLogger(true))
 
 	var (
-		name      = "clusteringress-operator"
-		namespace = "istio-system"
+		name       = "clusteringress-operator"
+		namespace  = "istio-system"
+		domainName = name + "." + namespace + ".default.domainName"
+		routeName  = "route-" + domainName
 	)
 
 	// A ClusterIngress resource with metadata and spec.
@@ -40,7 +42,7 @@ func TestClusterIngressController(t *testing.T) {
 		Spec: networkingv1alpha1.IngressSpec{
 			Visibility: networkingv1alpha1.IngressVisibilityExternalIP,
 			Rules: []networkingv1alpha1.IngressRule{{
-				Hosts: []string{"public.default.domainName"},
+				Hosts: []string{domainName},
 				HTTP: &networkingv1alpha1.HTTPIngressRuleValue{
 					Paths: []networkingv1alpha1.HTTPIngressPath{{
 						Timeout: &metav1.Duration{Duration: 5 * time.Second},
@@ -80,7 +82,7 @@ func TestClusterIngressController(t *testing.T) {
 	req := reconcile.Request{
 		NamespacedName: types.NamespacedName{
 			Name:      name,
-			Namespace: "istio-system",
+			Namespace: namespace,
 		},
 	}
 	_, err := r.Reconcile(req)
@@ -91,7 +93,7 @@ func TestClusterIngressController(t *testing.T) {
 	// Check if route has been created
 	routes := &routev1.Route{}
 
-	err = cl.Get(context.TODO(), types.NamespacedName{Name: "clusteringress-operator-0", Namespace: "istio-system"}, routes)
+	err = cl.Get(context.TODO(), types.NamespacedName{Name: routeName, Namespace: namespace}, routes)
 	if err != nil {
 		t.Fatalf("get route: (%v)", err)
 	}

--- a/pkg/controller/ingress/ingress_controller_test.go
+++ b/pkg/controller/ingress/ingress_controller_test.go
@@ -23,8 +23,10 @@ import (
 )
 
 const (
-	name      = "ingress-operator"
-	namespace = "istio-system"
+	name       = "ingress-operator"
+	namespace  = "istio-system"
+	domainName = name + "." + namespace + ".default.domainName"
+	routeName  = "route-" + domainName
 )
 
 var (
@@ -36,7 +38,7 @@ var (
 		Spec: networkingv1alpha1.IngressSpec{
 			Visibility: networkingv1alpha1.IngressVisibilityExternalIP,
 			Rules: []networkingv1alpha1.IngressRule{{
-				Hosts: []string{"public.default.domainName"},
+				Hosts: []string{domainName},
 				HTTP: &networkingv1alpha1.HTTPIngressRuleValue{
 					Paths: []networkingv1alpha1.HTTPIngressPath{{
 						Timeout: &metav1.Duration{Duration: 5 * time.Second},
@@ -129,7 +131,7 @@ func TestIngressController(t *testing.T) {
 
 			// Check if route has been created
 			routes := &routev1.Route{}
-			err := cl.Get(context.TODO(), types.NamespacedName{Name: "ingress-operator-0", Namespace: "istio-system"}, routes)
+			err := cl.Get(context.TODO(), types.NamespacedName{Name: routeName, Namespace: "istio-system"}, routes)
 
 			assert.True(t, test.wantErr(err))
 			assert.Equal(t, test.want, routes.ObjectMeta.Annotations)


### PR DESCRIPTION
Current log outputs a message like `"Failed to create OpenShift Route\"test-1\" in namespace \"istio-system\"`.
The service name was `test`, but we can not figure out what was the index number `1` for.

Hence, this patch changes to route object name to `"route-" +
domain`. Note, the domain must be unique in cluster, so the route name
will not be duplicate. (Also, this change refactors codes.)