### PR TITLE
[SRVKS-233] Make all routes tests table-tests, increase test coverage.

### DIFF
--- a/pkg/controller/resources/route.go
+++ b/pkg/controller/resources/route.go
@@ -25,7 +25,7 @@ const (
 
 var (
 	// ErrNotSupportedTLSTermination is an error when unsupported TLS termination is configured via annotation.
-	ErrNotSupportedTLSTermination = errors.New("not supported tls termination is specified. Only \"passthrough\" is valid")
+	ErrNotSupportedTLSTermination = errors.New("not supported tls termination is specified, only 'passthrough' is valid")
 
 	// ErrNoValidLoadbalancerDomain indicates that the current ingress does not have a DomainInternal field, or
 	// said field does not contain a value we can work with.

--- a/pkg/controller/resources/route_test.go
+++ b/pkg/controller/resources/route_test.go
@@ -1,194 +1,379 @@
 package resources
 
 import (
-	"errors"
+	"fmt"
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
-
+	"github.com/google/go-cmp/cmp"
 	routev1 "github.com/openshift/api/route/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"knative.dev/pkg/kmeta"
 	"knative.dev/serving/pkg/apis/networking"
 	networkingv1alpha1 "knative.dev/serving/pkg/apis/networking/v1alpha1"
 	"knative.dev/serving/pkg/apis/serving"
 )
 
-func TestMakeRouteWithNoRules(t *testing.T) {
-	ci := &networkingv1alpha1.ClusterIngress{
-		Spec: networkingv1alpha1.IngressSpec{
-			Visibility: networkingv1alpha1.IngressVisibilityExternalIP,
+const (
+	localDomain     = "test.default.svc.cluster.local"
+	externalDomain  = "public.default.domainName"
+	externalDomain2 = "another.public.default.domainName"
+
+	lbService   = "lb-service"
+	lbNamespace = "lb-namespace"
+)
+
+var ownerRef = *kmeta.NewControllerRef(ingress())
+
+func TestMakeRoute(t *testing.T) {
+	tests := []struct {
+		name    string
+		ingress networkingv1alpha1.IngressAccessor
+		want    []*routev1.Route
+		wantErr error
+	}{
+		{
+			name:    "no rules",
+			ingress: ingress(),
+			want:    []*routev1.Route{},
 		},
-	}
-
-	routes, err := MakeRoutes(ci)
-	assert.Zero(t, len(routes))
-	assert.Nil(t, err)
-}
-
-func TestMakeRouteInternalHost(t *testing.T) {
-	ci := &networkingv1alpha1.ClusterIngress{
-		Spec: networkingv1alpha1.IngressSpec{
-			Visibility: networkingv1alpha1.IngressVisibilityExternalIP,
-			Rules: []networkingv1alpha1.IngressRule{{
-				Hosts: []string{"test.default.svc.cluster.local"},
-			}},
+		{
+			name: "skip internal host name",
+			ingress: ingress(withRules(
+				rule(withHosts([]string{localDomain}))),
+			),
+			want: []*routev1.Route{},
 		},
-	}
-
-	routes, err := MakeRoutes(ci)
-	assert.Zero(t, len(routes))
-	assert.Nil(t, err)
-}
-
-func TestMakeRouteValidHost(t *testing.T) {
-	ci := &networkingv1alpha1.ClusterIngress{
-		Spec: networkingv1alpha1.IngressSpec{
-			Visibility: networkingv1alpha1.IngressVisibilityExternalIP,
-			Rules: []networkingv1alpha1.IngressRule{{
-				Hosts: []string{"public.default.domainName"},
-			}},
-		},
-	}
-
-	routes, err := MakeRoutes(ci)
-	assert.Zero(t, len(routes))
-	assert.Exactly(t, errors.New("Unable to find ClusterIngress LoadBalancer with DomainInternal set"), err)
-}
-
-func TestMakeRouteWithEmptyTimeout(t *testing.T) {
-	ci := &networkingv1alpha1.ClusterIngress{
-		Spec: networkingv1alpha1.IngressSpec{
-			Visibility: networkingv1alpha1.IngressVisibilityExternalIP,
-			Rules: []networkingv1alpha1.IngressRule{{
-				Hosts: []string{"public.default.domainName"},
-				HTTP: &networkingv1alpha1.HTTPIngressRuleValue{
-					Paths: []networkingv1alpha1.HTTPIngressPath{{}},
+		{
+			name: "valid, default timeout",
+			ingress: ingress(withRules(
+				rule(withHosts([]string{localDomain, externalDomain}))),
+			),
+			want: []*routev1.Route{{
+				ObjectMeta: metav1.ObjectMeta{
+					OwnerReferences: []metav1.OwnerReference{ownerRef},
+					Labels: map[string]string{
+						networking.IngressLabelKey:     "ingress",
+						serving.RouteLabelKey:          "route1",
+						serving.RouteNamespaceLabelKey: "default",
+					},
+					Annotations: map[string]string{
+						TimeoutAnnotation: "600s",
+					},
+					Namespace: lbNamespace,
+					Name:      "ingress-0",
+				},
+				Spec: routev1.RouteSpec{
+					Host: externalDomain,
+					To: routev1.RouteTargetReference{
+						Kind: "Service",
+						Name: lbService,
+					},
+					Port: &routev1.RoutePort{
+						TargetPort: intstr.FromString("http2"),
+					},
 				},
 			}},
 		},
-	}
-
-	routes, err := MakeRoutes(ci)
-	assert.Zero(t, len(routes))
-	assert.Exactly(t, errors.New("Unable to find ClusterIngress LoadBalancer with DomainInternal set"), err)
-}
-
-func TestMakeRouteForTimeout(t *testing.T) {
-	host := []string{"public.default.domainName", "local.default.domainName"}
-	ci := createClusterIngressObj("istio-ingressgateway.istio-system.svc.cluster.local", host)
-
-	routes, _ := MakeRoutes(ci)
-	for i, _ := range routes {
-		assert.Equal(t, "600s", routes[i].ObjectMeta.Annotations[TimeoutAnnotation])
-		assert.NotEqual(t, 10*time.Minute, routes[i].ObjectMeta.Annotations[TimeoutAnnotation])
-	}
-}
-
-func TestDisableRouteByAnnotation(t *testing.T) {
-	host := []string{"public.default.domainName", "local.default.domainName"}
-	ci := createClusterIngressObj("istio-ingressgateway.istio-system.svc.cluster.local", host)
-	ci.ObjectMeta.Annotations = map[string]string{DisableRouteAnnotation: ""}
-
-	routes, err := MakeRoutes(ci)
-	assert.Equal(t, []*routev1.Route{}, routes)
-	assert.Nil(t, err)
-}
-
-func TestMakeRouteInvalidDomain(t *testing.T) {
-	host := []string{"public.default.domainName"}
-	ci := createClusterIngressObj("istio-ingressgateway.istio-system.local.svc.test", host)
-
-	routes, err := MakeRoutes(ci)
-	assert.Zero(t, len(routes))
-	assert.Exactly(t, errors.New("Unable to find ClusterIngress LoadBalancer with DomainInternal set"), err)
-}
-
-func TestMakeRoute(t *testing.T) {
-	host := []string{"public.default.domainName", "public.default.svc.local"}
-	ci := createClusterIngressObj("istio-ingressgateway.istio-system.svc.cluster.local", host)
-
-	routes, err := MakeRoutes(ci)
-	assert.NotNil(t, routes)
-	assert.Nil(t, err)
-
-	for i, _ := range routes {
-		assert.Equal(t, routes[i].Labels[serving.RouteLabelKey], "route1")
-		assert.Equal(t, routes[i].Labels[networking.IngressLabelKey], "clusteringress")
-
-	}
-}
-
-func TestMakeSecuredRoute(t *testing.T) {
-	tests := []struct {
-		name           string
-		annotations    map[string]string
-		want           *routev1.TLSConfig
-		wantTargetPort intstr.IntOrString
-		wantErr        error
-	}{
 		{
-			name:        "Simple Passthrough termination",
-			annotations: map[string]string{TLSTerminationAnnotation: "passthrough"},
-			want: &routev1.TLSConfig{
-				Termination: routev1.TLSTerminationPassthrough,
-			},
-			wantTargetPort: intstr.FromString("https"),
-			wantErr:        nil,
+			name: "valid but disabled",
+			ingress: ingress(withDisabledAnnotation, withRules(
+				rule(withHosts([]string{localDomain, externalDomain}))),
+			),
+			want: []*routev1.Route{},
 		},
 		{
-			name:           "Unsupported termination",
-			annotations:    map[string]string{TLSTerminationAnnotation: "edge"},
-			want:           nil,
-			wantTargetPort: intstr.FromString("https"),
-			wantErr:        ErrNotSupportedTLSTermination,
+			name: "valid but cluster-local",
+			ingress: ingress(withLocalVisibility, withRules(
+				rule(withHosts([]string{localDomain, externalDomain}))),
+			),
+			want: []*routev1.Route{},
+		},
+		{
+			name: "valid, with timeout",
+			ingress: ingress(withRules(
+				rule(withHosts([]string{localDomain, externalDomain}), withTimeout(1*time.Hour))),
+			),
+			want: []*routev1.Route{{
+				ObjectMeta: metav1.ObjectMeta{
+					OwnerReferences: []metav1.OwnerReference{ownerRef},
+					Labels: map[string]string{
+						networking.IngressLabelKey:     "ingress",
+						serving.RouteLabelKey:          "route1",
+						serving.RouteNamespaceLabelKey: "default",
+					},
+					Annotations: map[string]string{
+						TimeoutAnnotation: "3600s",
+					},
+					Namespace: lbNamespace,
+					Name:      "ingress-0",
+				},
+				Spec: routev1.RouteSpec{
+					Host: externalDomain,
+					To: routev1.RouteTargetReference{
+						Kind: "Service",
+						Name: lbService,
+					},
+					Port: &routev1.RoutePort{
+						TargetPort: intstr.FromString("http2"),
+					},
+				},
+			}},
+		},
+		{
+			name: "valid, multiple rules",
+			ingress: ingress(withRules(
+				rule(withHosts([]string{localDomain, externalDomain})),
+				rule(withHosts([]string{localDomain, externalDomain2})),
+			)),
+			want: []*routev1.Route{{
+				ObjectMeta: metav1.ObjectMeta{
+					OwnerReferences: []metav1.OwnerReference{ownerRef},
+					Labels: map[string]string{
+						networking.IngressLabelKey:     "ingress",
+						serving.RouteLabelKey:          "route1",
+						serving.RouteNamespaceLabelKey: "default",
+					},
+					Annotations: map[string]string{
+						TimeoutAnnotation: "600s",
+					},
+					Namespace: lbNamespace,
+					Name:      "ingress-0",
+				},
+				Spec: routev1.RouteSpec{
+					Host: externalDomain,
+					To: routev1.RouteTargetReference{
+						Kind: "Service",
+						Name: lbService,
+					},
+					Port: &routev1.RoutePort{
+						TargetPort: intstr.FromString("http2"),
+					},
+				},
+			}, {
+				ObjectMeta: metav1.ObjectMeta{
+					OwnerReferences: []metav1.OwnerReference{ownerRef},
+					Labels: map[string]string{
+						networking.IngressLabelKey:     "ingress",
+						serving.RouteLabelKey:          "route1",
+						serving.RouteNamespaceLabelKey: "default",
+					},
+					Annotations: map[string]string{
+						TimeoutAnnotation: "600s",
+					},
+					Namespace: lbNamespace,
+					Name:      "ingress-1",
+				},
+				Spec: routev1.RouteSpec{
+					Host: externalDomain2,
+					To: routev1.RouteTargetReference{
+						Kind: "Service",
+						Name: lbService,
+					},
+					Port: &routev1.RoutePort{
+						TargetPort: intstr.FromString("http2"),
+					},
+				},
+			}},
+		},
+		{
+			name: "valid, multiple rules, one local",
+			ingress: ingress(withRules(
+				rule(withHosts([]string{localDomain, externalDomain}), withLocalVisibilityRule),
+				rule(withHosts([]string{localDomain, externalDomain2})),
+			)),
+			want: []*routev1.Route{{
+				ObjectMeta: metav1.ObjectMeta{
+					OwnerReferences: []metav1.OwnerReference{ownerRef},
+					Labels: map[string]string{
+						networking.IngressLabelKey:     "ingress",
+						serving.RouteLabelKey:          "route1",
+						serving.RouteNamespaceLabelKey: "default",
+					},
+					Annotations: map[string]string{
+						TimeoutAnnotation: "600s",
+					},
+					Namespace: lbNamespace,
+					Name:      "ingress-1",
+				},
+				Spec: routev1.RouteSpec{
+					Host: externalDomain2,
+					To: routev1.RouteTargetReference{
+						Kind: "Service",
+						Name: lbService,
+					},
+					Port: &routev1.RoutePort{
+						TargetPort: intstr.FromString("http2"),
+					},
+				},
+			}},
+		},
+		{
+			name: "invalid LB domain",
+			ingress: ingress(withLBInternalDomain("not.a.private.name"), withRules(
+				rule(withHosts([]string{localDomain, externalDomain}))),
+			),
+			wantErr: ErrNoValidLoadbalancerDomain,
+		},
+		{
+			name: "tls: passthrough termination",
+			ingress: ingress(withTLSTerminationAnnotation("passthrough"), withRules(
+				rule(withHosts([]string{localDomain, externalDomain}))),
+			),
+			want: []*routev1.Route{{
+				ObjectMeta: metav1.ObjectMeta{
+					OwnerReferences: []metav1.OwnerReference{ownerRef},
+					Labels: map[string]string{
+						networking.IngressLabelKey:     "ingress",
+						serving.RouteLabelKey:          "route1",
+						serving.RouteNamespaceLabelKey: "default",
+					},
+					Annotations: map[string]string{
+						TimeoutAnnotation:        "600s",
+						TLSTerminationAnnotation: "passthrough",
+					},
+					Namespace: lbNamespace,
+					Name:      "ingress-0",
+				},
+				Spec: routev1.RouteSpec{
+					Host: externalDomain,
+					To: routev1.RouteTargetReference{
+						Kind: "Service",
+						Name: lbService,
+					},
+					Port: &routev1.RoutePort{
+						TargetPort: intstr.FromString("https"),
+					},
+					TLS: &routev1.TLSConfig{
+						Termination: routev1.TLSTerminationPassthrough,
+					},
+				},
+			}},
+		},
+		{
+			name: "tls: unsupported termination",
+			ingress: ingress(withTLSTerminationAnnotation("edge"), withRules(
+				rule(withHosts([]string{localDomain, externalDomain}))),
+			),
+			wantErr: ErrNotSupportedTLSTermination,
 		},
 	}
 
 	for _, test := range tests {
-		host := []string{"public.default.domainName", "public.default.svc.local"}
-		ci := createClusterIngressObj("istio-ingressgateway.istio-system.svc.cluster.local", host)
-		ci.ObjectMeta.Annotations = test.annotations
 		t.Run(test.name, func(t *testing.T) {
-
-			routes, err := MakeRoutes(ci)
-			assert.Equal(t, test.wantErr, err)
-			for i, _ := range routes {
-				assert.Equal(t, test.want, routes[i].Spec.TLS)
-				assert.Equal(t, test.wantTargetPort, routes[i].Spec.Port.TargetPort)
+			routes, err := MakeRoutes(test.ingress)
+			if test.want != nil && !cmp.Equal(routes, test.want) {
+				t.Errorf("Got = %v, want: %v, diff: %s", routes, test.want, cmp.Diff(routes, test.want))
+			}
+			if err != test.wantErr {
+				t.Errorf("Got = %v, want: %v", err, test.wantErr)
 			}
 		})
 	}
 }
 
-func createClusterIngressObj(domainInternal string, host []string) *networkingv1alpha1.ClusterIngress {
-	return &networkingv1alpha1.ClusterIngress{
+func ingress(options ...ingressOption) networkingv1alpha1.IngressAccessor {
+	ing := &networkingv1alpha1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
 			Labels: map[string]string{
 				serving.RouteLabelKey:          "route1",
 				serving.RouteNamespaceLabelKey: "default",
 			},
-			Name: "clusteringress",
+			Namespace: "default",
+			Name:      "ingress",
 		},
 		Spec: networkingv1alpha1.IngressSpec{
 			Visibility: networkingv1alpha1.IngressVisibilityExternalIP,
-			Rules: []networkingv1alpha1.IngressRule{{
-				Hosts: host,
-				HTTP: &networkingv1alpha1.HTTPIngressRuleValue{
-					Paths: []networkingv1alpha1.HTTPIngressPath{{
-						Timeout: &metav1.Duration{Duration: 10 * time.Minute},
-					}},
-				},
-			}},
 		},
 		Status: networkingv1alpha1.IngressStatus{
 			LoadBalancer: &networkingv1alpha1.LoadBalancerStatus{
 				Ingress: []networkingv1alpha1.LoadBalancerIngressStatus{{
-					DomainInternal: domainInternal,
+					DomainInternal: fmt.Sprintf("%s.%s.svc.cluster.local", lbService, lbNamespace),
 				}},
 			},
 		},
 	}
 
+	for _, opt := range options {
+		opt(ing)
+	}
+
+	return ing
+}
+
+func rule(options ...ruleOption) networkingv1alpha1.IngressRule {
+	rule := networkingv1alpha1.IngressRule{
+		HTTP: &networkingv1alpha1.HTTPIngressRuleValue{
+			Paths: []networkingv1alpha1.HTTPIngressPath{{}},
+		},
+	}
+
+	for _, opt := range options {
+		opt(&rule)
+	}
+
+	return rule
+}
+
+type ingressOption func(networkingv1alpha1.IngressAccessor)
+
+func withRules(rules ...networkingv1alpha1.IngressRule) ingressOption {
+	return func(ing networkingv1alpha1.IngressAccessor) {
+		spec := ing.GetSpec()
+		spec.Rules = rules
+	}
+}
+
+func withDisabledAnnotation(ing networkingv1alpha1.IngressAccessor) {
+	annos := ing.GetAnnotations()
+	if annos == nil {
+		annos = map[string]string{}
+	}
+	annos[DisableRouteAnnotation] = ""
+	ing.SetAnnotations(annos)
+}
+
+func withTLSTerminationAnnotation(value string) ingressOption {
+	return func(ing networkingv1alpha1.IngressAccessor) {
+		annos := ing.GetAnnotations()
+		if annos == nil {
+			annos = map[string]string{}
+		}
+		annos[TLSTerminationAnnotation] = value
+		ing.SetAnnotations(annos)
+	}
+}
+
+func withLocalVisibility(ing networkingv1alpha1.IngressAccessor) {
+	ing.GetSpec().Visibility = networkingv1alpha1.IngressVisibilityClusterLocal
+}
+
+func withLBInternalDomain(domain string) ingressOption {
+	return func(ing networkingv1alpha1.IngressAccessor) {
+		status := ing.GetStatus()
+		status.LoadBalancer.Ingress[0].DomainInternal = domain
+	}
+}
+
+type ruleOption func(*networkingv1alpha1.IngressRule)
+
+func withLocalVisibilityRule(rule *networkingv1alpha1.IngressRule) {
+	rule.Visibility = networkingv1alpha1.IngressVisibilityClusterLocal
+}
+
+func withHosts(hosts []string) ruleOption {
+	return func(rule *networkingv1alpha1.IngressRule) {
+		rule.Hosts = hosts
+	}
+}
+
+func withTimeout(timeout time.Duration) ruleOption {
+	return func(rule *networkingv1alpha1.IngressRule) {
+		rule.HTTP = &networkingv1alpha1.HTTPIngressRuleValue{
+			Paths: []networkingv1alpha1.HTTPIngressPath{{
+				Timeout: &metav1.Duration{Duration: timeout},
+			}},
+		}
+	}
 }

--- a/pkg/controller/resources/route_test.go
+++ b/pkg/controller/resources/route_test.go
@@ -264,10 +264,10 @@ func TestMakeRoute(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			routes, err := MakeRoutes(test.ingress)
 			if test.want != nil && !cmp.Equal(routes, test.want) {
-				t.Errorf("Got = %v, want: %v, diff: %s", routes, test.want, cmp.Diff(routes, test.want))
+				t.Errorf("got = %v, want: %v, diff: %s", routes, test.want, cmp.Diff(routes, test.want))
 			}
 			if err != test.wantErr {
-				t.Errorf("Got = %v, want: %v", err, test.wantErr)
+				t.Errorf("got = %v, want: %v", err, test.wantErr)
 			}
 		})
 	}


### PR DESCRIPTION
- All `MakeRoute` tests have been converted into a table test.
- Vastly improved test coverage as the resulting route objects are now actually asserted in full.
- Added functionality to skip cluster-local ingresses and rules explicitly.
- Added testcases for multiple rules, cluster-local ingresses, cluster-local rules.