### PR TITLE
Change Route name to unique

### DIFF
--- a/pkg/controller/common/reconciler.go
+++ b/pkg/controller/common/reconciler.go
@@ -59,7 +59,7 @@ func (r *BaseIngressReconciler) ReconcileIngress(ctx context.Context, ci network
 		}
 		// If routes remains in existingMap, it must be obsoleted routes. Clean them up.
 		for _, rt := range existingMap {
-			logger.Infof("Deleting obsoleted route: %s", rt.Name)
+			logger.Infof("Deleting obsoleted route for host: %s", rt.Spec.Host)
 			if err := r.deleteRoute(ctx, rt); err != nil {
 				return err
 			}

--- a/pkg/controller/common/reconciler.go
+++ b/pkg/controller/common/reconciler.go
@@ -53,7 +53,7 @@ func (r *BaseIngressReconciler) ReconcileIngress(ctx context.Context, ci network
 		for _, route := range routes {
 			logger.Infof("Creating/Updating OpenShift Route for host %s", route.Spec.Host)
 			if err := r.reconcileRoute(ctx, ci, route); err != nil {
-				return err
+				return fmt.Errorf("failed to create route for host %s: %v", route.Spec.Host, err)
 			}
 			delete(existingMap, route.Name)
 		}

--- a/pkg/controller/common/reconciler.go
+++ b/pkg/controller/common/reconciler.go
@@ -12,6 +12,7 @@ import (
 	"knative.dev/pkg/logging"
 	"knative.dev/serving/pkg/apis/networking"
 	networkingv1alpha1 "knative.dev/serving/pkg/apis/networking/v1alpha1"
+	"knative.dev/serving/pkg/apis/serving"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -30,9 +31,12 @@ func (r *BaseIngressReconciler) ReconcileIngress(ctx context.Context, ci network
 
 	exposed := ci.GetSpec().Visibility == networkingv1alpha1.IngressVisibilityExternalIP
 	if exposed {
+		ingressLabels := ci.GetLabels()
 		listOpts := &client.ListOptions{
 			LabelSelector: labels.SelectorFromSet(map[string]string{
-				networking.IngressLabelKey: ci.GetName(),
+				networking.IngressLabelKey:     ci.GetName(),
+				serving.RouteLabelKey:          ingressLabels[serving.RouteLabelKey],
+				serving.RouteNamespaceLabelKey: ingressLabels[serving.RouteNamespaceLabelKey],
 			}),
 		}
 		var existing routev1.RouteList
@@ -52,10 +56,12 @@ func (r *BaseIngressReconciler) ReconcileIngress(ctx context.Context, ci network
 			}
 			delete(existingMap, route.Name)
 		}
-		// If routes remains in existingMap, it must be obsoleted routes. Clean up them.
+		// If routes remains in existingMap, it must be obsoleted routes. Clean them up.
 		for _, rt := range existingMap {
 			logger.Infof("Deleting obsoleted route: %s", rt.Name)
-			r.deleteRoute(ctx, rt)
+			if err := r.deleteRoute(ctx, rt); err != nil {
+				logger.Warnf("Failed to delete obsoleted route %s: %v", rt.Name, err)
+			}
 		}
 	} else {
 		r.deleteRoutes(ctx, ci)
@@ -66,7 +72,7 @@ func (r *BaseIngressReconciler) ReconcileIngress(ctx context.Context, ci network
 }
 
 func routeMap(routes routev1.RouteList) map[string]*routev1.Route {
-	mp := map[string]*routev1.Route{}
+	mp := make(map[string]*routev1.Route, len(routes.Items))
 	for _, route := range routes.Items {
 		mp[route.Name] = &route
 	}

--- a/pkg/controller/ingress/ingress_controller_test.go
+++ b/pkg/controller/ingress/ingress_controller_test.go
@@ -25,7 +25,9 @@ import (
 const (
 	name       = "ingress-operator"
 	namespace  = "istio-system"
+	uid        = "8a7e9a9d-fbc6-11e9-a88e-0261aff8d6d8"
 	domainName = name + "." + namespace + ".default.domainName"
+	routeName0 = "route-" + uid + "-0"
 )
 
 var (
@@ -33,6 +35,7 @@ var (
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
+			UID:       uid,
 		},
 		Spec: networkingv1alpha1.IngressSpec{
 			Visibility: networkingv1alpha1.IngressVisibilityExternalIP,
@@ -69,7 +72,7 @@ func TestRouteMigration(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{Name: "test-0"},
 			Spec:       routev1.RouteSpec{Host: domainName},
 		},
-		wantName:    domainName,
+		wantName:    routeName0,
 		removedName: "test-0",
 	}
 
@@ -185,7 +188,7 @@ func TestIngressController(t *testing.T) {
 
 			// Check if route has been created
 			routes := &routev1.Route{}
-			err := cl.Get(context.TODO(), types.NamespacedName{Name: domainName, Namespace: namespace}, routes)
+			err := cl.Get(context.TODO(), types.NamespacedName{Name: routeName0, Namespace: namespace}, routes)
 
 			assert.True(t, test.wantErr(err))
 			assert.Equal(t, test.want, routes.ObjectMeta.Annotations)

--- a/pkg/controller/resources/route.go
+++ b/pkg/controller/resources/route.go
@@ -41,7 +41,6 @@ func MakeRoutes(ci networkingv1alpha1.IngressAccessor) ([]*routev1.Route, error)
 		return routes, nil
 	}
 
-	routeIndex := 0
 	for _, rule := range ci.GetSpec().Rules {
 		for _, host := range rule.Hosts {
 			// Ignore domains like myksvc.myproject.svc.cluster.local
@@ -51,8 +50,7 @@ func MakeRoutes(ci networkingv1alpha1.IngressAccessor) ([]*routev1.Route, error)
 			// point.
 			parts := strings.Split(host, ".")
 			if len(parts) > 2 && parts[2] != "svc" {
-				route, err := makeRoute(ci, host, routeIndex, rule)
-				routeIndex = routeIndex + 1
+				route, err := makeRoute(ci, host, rule)
 				if err != nil {
 					return nil, err
 				}
@@ -67,7 +65,7 @@ func MakeRoutes(ci networkingv1alpha1.IngressAccessor) ([]*routev1.Route, error)
 	return routes, nil
 }
 
-func makeRoute(ci networkingv1alpha1.IngressAccessor, host string, index int, rule networkingv1alpha1.IngressRule) (*routev1.Route, error) {
+func makeRoute(ci networkingv1alpha1.IngressAccessor, host string, rule networkingv1alpha1.IngressRule) (*routev1.Route, error) {
 	// Take over annotaitons from ingress.
 	annotations := ci.GetAnnotations()
 	if annotations == nil {
@@ -108,7 +106,6 @@ func makeRoute(ci networkingv1alpha1.IngressAccessor, host string, index int, ru
 	labels[serving.RouteLabelKey] = ingressLabels[serving.RouteLabelKey]
 	labels[serving.RouteNamespaceLabelKey] = ingressLabels[serving.RouteNamespaceLabelKey]
 
-	name := fmt.Sprintf("%s-%d", ci.GetName(), index)
 	serviceName := ""
 	namespace := ""
 	if ci.GetStatus().LoadBalancer != nil {
@@ -131,7 +128,7 @@ func makeRoute(ci networkingv1alpha1.IngressAccessor, host string, index int, ru
 
 	route := &routev1.Route{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:            name,
+			Name:            host,
 			Namespace:       namespace,
 			OwnerReferences: []metav1.OwnerReference{*kmeta.NewControllerRef(ci)},
 			Labels:          labels,

--- a/pkg/controller/resources/route_test.go
+++ b/pkg/controller/resources/route_test.go
@@ -22,6 +22,10 @@ const (
 
 	lbService   = "lb-service"
 	lbNamespace = "lb-namespace"
+
+	uid        = "8a7e9a9d-fbc6-11e9-a88e-0261aff8d6d8"
+	routeName0 = "route-" + uid + "-0"
+	routeName1 = "route-" + uid + "-1"
 )
 
 var ownerRef = *kmeta.NewControllerRef(ingress())
@@ -62,7 +66,7 @@ func TestMakeRoute(t *testing.T) {
 						TimeoutAnnotation: "600s",
 					},
 					Namespace: lbNamespace,
-					Name:      externalDomain,
+					Name:      routeName0,
 				},
 				Spec: routev1.RouteSpec{
 					Host: externalDomain,
@@ -107,7 +111,7 @@ func TestMakeRoute(t *testing.T) {
 						TimeoutAnnotation: "3600s",
 					},
 					Namespace: lbNamespace,
-					Name:      externalDomain,
+					Name:      routeName0,
 				},
 				Spec: routev1.RouteSpec{
 					Host: externalDomain,
@@ -139,7 +143,7 @@ func TestMakeRoute(t *testing.T) {
 						TimeoutAnnotation: "600s",
 					},
 					Namespace: lbNamespace,
-					Name:      externalDomain,
+					Name:      routeName0,
 				},
 				Spec: routev1.RouteSpec{
 					Host: externalDomain,
@@ -163,7 +167,7 @@ func TestMakeRoute(t *testing.T) {
 						TimeoutAnnotation: "600s",
 					},
 					Namespace: lbNamespace,
-					Name:      externalDomain2,
+					Name:      routeName1,
 				},
 				Spec: routev1.RouteSpec{
 					Host: externalDomain2,
@@ -195,7 +199,7 @@ func TestMakeRoute(t *testing.T) {
 						TimeoutAnnotation: "600s",
 					},
 					Namespace: lbNamespace,
-					Name:      externalDomain2,
+					Name:      routeName1,
 				},
 				Spec: routev1.RouteSpec{
 					Host: externalDomain2,
@@ -234,7 +238,7 @@ func TestMakeRoute(t *testing.T) {
 						TLSTerminationAnnotation: "passthrough",
 					},
 					Namespace: lbNamespace,
-					Name:      externalDomain,
+					Name:      routeName0,
 				},
 				Spec: routev1.RouteSpec{
 					Host: externalDomain,
@@ -282,6 +286,7 @@ func ingress(options ...ingressOption) networkingv1alpha1.IngressAccessor {
 			},
 			Namespace: "default",
 			Name:      "ingress",
+			UID:       uid,
 		},
 		Spec: networkingv1alpha1.IngressSpec{
 			Visibility: networkingv1alpha1.IngressVisibilityExternalIP,

--- a/pkg/controller/resources/route_test.go
+++ b/pkg/controller/resources/route_test.go
@@ -62,7 +62,7 @@ func TestMakeRoute(t *testing.T) {
 						TimeoutAnnotation: "600s",
 					},
 					Namespace: lbNamespace,
-					Name:      "ingress-0",
+					Name:      externalDomain,
 				},
 				Spec: routev1.RouteSpec{
 					Host: externalDomain,
@@ -107,7 +107,7 @@ func TestMakeRoute(t *testing.T) {
 						TimeoutAnnotation: "3600s",
 					},
 					Namespace: lbNamespace,
-					Name:      "ingress-0",
+					Name:      externalDomain,
 				},
 				Spec: routev1.RouteSpec{
 					Host: externalDomain,
@@ -139,7 +139,7 @@ func TestMakeRoute(t *testing.T) {
 						TimeoutAnnotation: "600s",
 					},
 					Namespace: lbNamespace,
-					Name:      "ingress-0",
+					Name:      externalDomain,
 				},
 				Spec: routev1.RouteSpec{
 					Host: externalDomain,
@@ -163,7 +163,7 @@ func TestMakeRoute(t *testing.T) {
 						TimeoutAnnotation: "600s",
 					},
 					Namespace: lbNamespace,
-					Name:      "ingress-1",
+					Name:      externalDomain2,
 				},
 				Spec: routev1.RouteSpec{
 					Host: externalDomain2,
@@ -195,7 +195,7 @@ func TestMakeRoute(t *testing.T) {
 						TimeoutAnnotation: "600s",
 					},
 					Namespace: lbNamespace,
-					Name:      "ingress-1",
+					Name:      externalDomain2,
 				},
 				Spec: routev1.RouteSpec{
 					Host: externalDomain2,
@@ -234,7 +234,7 @@ func TestMakeRoute(t *testing.T) {
 						TLSTerminationAnnotation: "passthrough",
 					},
 					Namespace: lbNamespace,
-					Name:      "ingress-0",
+					Name:      externalDomain,
 				},
 				Spec: routev1.RouteSpec{
 					Host: externalDomain,


### PR DESCRIPTION
This patch changes reconciler of Route to:

- [x] use route name to unique by route's domain
- [x] clean up obsoleted route if found