### PR TITLE
Do not ignore error on ingress reconciliation

### DIFF
--- a/pkg/controller/ingress/ingress_controller.go
+++ b/pkg/controller/ingress/ingress_controller.go
@@ -107,7 +107,9 @@ func (r *ReconcileIngress) Reconcile(request reconcile.Request) (reconcile.Resul
 
 	// Don't modify the informer's copy
 	ci := original.DeepCopy()
-	err = r.base.ReconcileIngress(ctx, ci)
+	if err = r.base.ReconcileIngress(ctx, ci); err != nil {
+		return reconcile.Result{}, err
+	}
 	if equality.Semantic.DeepEqual(original.Status, ci.Status) {
 		// If we didn't change anything then don't call updateStatus.
 		// This is important because the copy we loaded from the informer's


### PR DESCRIPTION
I got no ingress reconciled without a reason, now I have a reason, even if no clue about that ;)


Any hint? this is the error I'm getting now:
```
{"level":"info","ts":1572955547.78623,"logger":"fallback","caller":"common/reconciler.go:31","msg":"Reconciling ingress :&{{Ingress networking.internal.knative.dev/v1alpha1} {sample  camel-k /apis/networking.internal.knative.dev/v1alpha1/namespaces/camel-k/ingresses/sample 7b742bca-ffc0-11e9-8bef-0694e72ccc58 1453843 1 2019-11-05 12:36:18 +0100 CET <nil> <nil> map[serving.knative.dev/route:sample serving.knative.dev/routeNamespace:camel-k] map[networking.knative.dev/ingress.class:istio.ingress.networking.knative.dev serving.knative.dev/creator:kube:admin serving.knative.dev/lastModifier:kube:admin] [{serving.knative.dev/v1alpha1 Route sample 72bfe2eb-ffc0-11e9-8bef-0694e72ccc58 0xc000fa2400 0xc000fa2401}] nil [] } {0 [] [{[sample.camel-k.svc.cluster.local sample.camel-k.apps.camel-k.rhmw-integrations.net] ExternalIP 0xc000855bc0}] ExternalIP} {{1 [{LoadBalancerReady Unknown  {2019-11-05 12:36:18 +0100 CET} Uninitialized Waiting for VirtualService to be ready} {NetworkConfigured True  {2019-11-05 12:36:18 +0100 CET}  } {Ready Unknown  {2019-11-05 12:36:18 +0100 CET} Uninitialized Waiting for VirtualService to be ready}]} <nil> <nil> <nil>}}"}
{"level":"error","ts":1572955547.7864275,"logger":"kubebuilder.controller","msg":"Reconciler error","controller":"ingress-controller","request":"camel-k/sample","error":"unable to find Ingress LoadBalancer with DomainInternal set","stacktrace":"github.com/openshift-knative/knative-openshift-ingress/vendor/github.com/go-logr/zapr.(*zapLogger).Error\n\t/home/nferraro/gopaths/knative/src/github.com/openshift-knative/knative-openshift-ingress/vendor/github.com/go-logr/zapr/zapr.go:128\ngithub.com/openshift-knative/knative-openshift-ingress/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\t/home/nferraro/gopaths/knative/src/github.com/openshift-knative/knative-openshift-ingress/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:217\ngithub.com/openshift-knative/knative-openshift-ingress/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func1\n\t/home/nferraro/gopaths/knative/src/github.com/openshift-knative/knative-openshift-ingress/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:158\ngithub.com/openshift-knative/knative-openshift-ingress/vendor/k8s.io/apimachinery/pkg/util/wait.JitterUntil.func1\n\t/home/nferraro/gopaths/knative/src/github.com/openshift-knative/knative-openshift-ingress/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:133\ngithub.com/openshift-knative/knative-openshift-ingress/vendor/k8s.io/apimachinery/pkg/util/wait.JitterUntil\n\t/home/nferraro/gopaths/knative/src/github.com/openshift-knative/knative-openshift-ingress/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:134\ngithub.com/openshift-knative/knative-openshift-ingress/vendor/k8s.io/apimachinery/pkg/util/wait.Until\n\t/home/nferraro/gopaths/knative/src/github.com/openshift-knative/knative-openshift-ingress/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:88"}
```