### PR TITLE
Actually return the reconciler error if it happens.

### DIFF
--- a/pkg/controller/clusteringress/clusteringress_controller.go
+++ b/pkg/controller/clusteringress/clusteringress_controller.go
@@ -103,18 +103,17 @@ func (r *ReconcileClusterIngress) Reconcile(request reconcile.Request) (reconcil
 
 	// Don't modify the informer's copy
 	ci := original.DeepCopy()
-	err = r.base.ReconcileIngress(ctx, ci)
+	reconcileErr := r.base.ReconcileIngress(ctx, ci)
 	if equality.Semantic.DeepEqual(original.Status, ci.Status) {
 		// If we didn't change anything then don't call updateStatus.
 		// This is important because the copy we loaded from the informer's
 		// cache may be stale and we don't want to overwrite a prior update
 		// to status with this stale state.
 	} else if _, err := r.updateStatus(ctx, ci); err != nil {
-		logger.Warnw("Failed to update clusterIngress status", err)
-		return reconcile.Result{}, err
+		logger.Errorf("Failed to update clusterIngress status %v", err)
 	}
 
-	return reconcile.Result{}, nil
+	return reconcile.Result{}, reconcileErr
 }
 
 // Update the Status of the ClusterIngress.  Caller is responsible for checking

--- a/pkg/controller/clusteringress/clusteringress_controller.go
+++ b/pkg/controller/clusteringress/clusteringress_controller.go
@@ -111,6 +111,7 @@ func (r *ReconcileClusterIngress) Reconcile(request reconcile.Request) (reconcil
 		// to status with this stale state.
 	} else if _, err := r.updateStatus(ctx, ci); err != nil {
 		logger.Errorf("Failed to update clusterIngress status %v", err)
+		return reconcile.Result{}, err
 	}
 
 	return reconcile.Result{}, reconcileErr

--- a/pkg/controller/common/reconciler.go
+++ b/pkg/controller/common/reconciler.go
@@ -49,7 +49,9 @@ func (r *BaseIngressReconciler) ReconcileIngress(ctx context.Context, ci network
 
 		routes, err := resources.MakeRoutes(ci)
 		if err != nil {
-			return err
+			logger.Warnf("Failed to generate routes from ingress %v", err)
+			// Returning nil aborts the reconcilation. It will be retriggered once the status of the ingress changes.
+			return nil
 		}
 		for _, route := range routes {
 			logger.Infof("Creating/Updating OpenShift Route for host %s", route.Spec.Host)

--- a/pkg/controller/ingress/ingress_controller.go
+++ b/pkg/controller/ingress/ingress_controller.go
@@ -116,6 +116,7 @@ func (r *ReconcileIngress) Reconcile(request reconcile.Request) (reconcile.Resul
 	} else if _, err := r.updateStatus(ctx, ci); err != nil {
 		logger.Errorf("Failed to update ingress status %v", err)
 		r.recorder.Event(ci, corev1.EventTypeWarning, "SyncError", err.Error())
+		return reconcile.Result{}, err
 	}
 
 	return reconcile.Result{}, reconcileErr

--- a/pkg/controller/ingress/ingress_controller.go
+++ b/pkg/controller/ingress/ingress_controller.go
@@ -107,19 +107,18 @@ func (r *ReconcileIngress) Reconcile(request reconcile.Request) (reconcile.Resul
 
 	// Don't modify the informer's copy
 	ci := original.DeepCopy()
-	err = r.base.ReconcileIngress(ctx, ci)
+	reconcileErr := r.base.ReconcileIngress(ctx, ci)
 	if equality.Semantic.DeepEqual(original.Status, ci.Status) {
 		// If we didn't change anything then don't call updateStatus.
 		// This is important because the copy we loaded from the informer's
 		// cache may be stale and we don't want to overwrite a prior update
 		// to status with this stale state.
 	} else if _, err := r.updateStatus(ctx, ci); err != nil {
-		logger.Warnw("Failed to update ingress status", err)
+		logger.Errorf("Failed to update ingress status %v", err)
 		r.recorder.Event(ci, corev1.EventTypeWarning, "SyncError", err.Error())
-		return reconcile.Result{}, err
 	}
 
-	return reconcile.Result{}, nil
+	return reconcile.Result{}, reconcileErr
 }
 
 // Update the Status of the Ingress.  Caller is responsible for checking


### PR DESCRIPTION
Not returning the error from the reconciler has two nasty side-effects:
1. It is not logged and thus it's not debuggable.
2. It is not retried so transient errors do not resolve themselves.