### PR TITLE
Install a default allow-all NetworkPolicy

### DIFF
--- a/pkg/controller/ingress/ingress_controller_test.go
+++ b/pkg/controller/ingress/ingress_controller_test.go
@@ -10,8 +10,10 @@ import (
 	"github.com/openshift-knative/knative-openshift-ingress/pkg/controller/resources"
 	routev1 "github.com/openshift/api/route/v1"
 	"github.com/stretchr/testify/assert"
+	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -182,46 +184,162 @@ func TestIngressController(t *testing.T) {
 	logf.SetLogger(logf.ZapLogger(true))
 
 	tests := []struct {
-		name        string
-		annotations map[string]string
-		want        map[string]string
-		wantErr     func(err error) bool
+		name              string
+		annotations       map[string]string
+		want              map[string]string
+		wantRouteErr      func(err error) bool
+		wantSmmr          bool
+		wantNetworkPolicy bool
+		extraObjs         []runtime.Object
 	}{
 		{
-			name:        "reconcile route with timeout annotation",
-			annotations: map[string]string{},
-			want:        map[string]string{resources.TimeoutAnnotation: "5s", networking.IngressClassAnnotationKey: network.IstioIngressClassName},
-			wantErr:     func(err error) bool { return err == nil },
+			name:              "reconcile route with timeout annotation",
+			annotations:       map[string]string{},
+			want:              map[string]string{resources.TimeoutAnnotation: "5s", networking.IngressClassAnnotationKey: network.IstioIngressClassName},
+			wantRouteErr:      func(err error) bool { return err == nil },
+			wantSmmr:          true,
+			wantNetworkPolicy: true,
 		},
 		{
-			name:        "reconcile route with taking over annotations",
-			annotations: map[string]string{serving.CreatorAnnotation: "userA", serving.UpdaterAnnotation: "userB"},
-			want:        map[string]string{serving.CreatorAnnotation: "userA", serving.UpdaterAnnotation: "userB", resources.TimeoutAnnotation: "5s", networking.IngressClassAnnotationKey: network.IstioIngressClassName},
-			wantErr:     func(err error) bool { return err == nil },
+			name:              "reconcile route with taking over annotations",
+			annotations:       map[string]string{serving.CreatorAnnotation: "userA", serving.UpdaterAnnotation: "userB"},
+			want:              map[string]string{serving.CreatorAnnotation: "userA", serving.UpdaterAnnotation: "userB", resources.TimeoutAnnotation: "5s", networking.IngressClassAnnotationKey: network.IstioIngressClassName},
+			wantRouteErr:      func(err error) bool { return err == nil },
+			wantSmmr:          true,
+			wantNetworkPolicy: true,
 		},
 		{
-			name:        "do not reconcile with disable route annotation",
-			annotations: map[string]string{resources.DisableRouteAnnotation: ""},
-			want:        nil,
-			wantErr:     errors.IsNotFound,
+			name:              "do not reconcile with disable route annotation",
+			annotations:       map[string]string{resources.DisableRouteAnnotation: ""},
+			want:              nil,
+			wantRouteErr:      errors.IsNotFound,
+			wantSmmr:          true,
+			wantNetworkPolicy: true,
 		},
 		{
-			name:        "reconcile route with passthrough annotation",
-			annotations: map[string]string{resources.TLSTerminationAnnotation: "passthrough"},
-			want:        map[string]string{resources.TLSTerminationAnnotation: "passthrough", resources.TimeoutAnnotation: "5s", networking.IngressClassAnnotationKey: network.IstioIngressClassName},
-			wantErr:     func(err error) bool { return err == nil },
+			name:              "reconcile route with passthrough annotation",
+			annotations:       map[string]string{resources.TLSTerminationAnnotation: "passthrough"},
+			want:              map[string]string{resources.TLSTerminationAnnotation: "passthrough", resources.TimeoutAnnotation: "5s", networking.IngressClassAnnotationKey: network.IstioIngressClassName},
+			wantRouteErr:      func(err error) bool { return err == nil },
+			wantSmmr:          true,
+			wantNetworkPolicy: true,
 		},
 		{
-			name:        "reconcile route with invalid TLS termination annotation",
-			annotations: map[string]string{resources.TLSTerminationAnnotation: "edge"},
-			want:        nil,
-			wantErr:     errors.IsNotFound,
+			name:              "reconcile route with invalid TLS termination annotation",
+			annotations:       map[string]string{resources.TLSTerminationAnnotation: "edge"},
+			want:              nil,
+			wantRouteErr:      errors.IsNotFound,
+			wantSmmr:          true,
+			wantNetworkPolicy: true,
 		},
 		{
-			name:        "reconcile route with different ingress annotation",
-			annotations: map[string]string{networking.IngressClassAnnotationKey: "kourier"},
-			want:        map[string]string{networking.IngressClassAnnotationKey: "kourier", resources.TimeoutAnnotation: "5s"},
-			wantErr:     func(err error) bool { return err == nil },
+			name:              "reconcile route with different ingress annotation",
+			annotations:       map[string]string{networking.IngressClassAnnotationKey: "kourier"},
+			want:              map[string]string{networking.IngressClassAnnotationKey: "kourier", resources.TimeoutAnnotation: "5s"},
+			wantRouteErr:      func(err error) bool { return err == nil },
+			wantSmmr:          false,
+			wantNetworkPolicy: false,
+		},
+		{
+			name:              "reconcile with existing managed NetworkPolicy",
+			annotations:       map[string]string{},
+			want:              map[string]string{resources.TimeoutAnnotation: "5s", networking.IngressClassAnnotationKey: network.IstioIngressClassName},
+			wantRouteErr:      func(err error) bool { return err == nil },
+			wantSmmr:          true,
+			wantNetworkPolicy: true,
+			extraObjs: []runtime.Object{
+				&networkingv1.NetworkPolicy{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      resources.NetworkPolicyAllowAllName,
+						Namespace: namespace,
+					},
+					Spec: networkingv1.NetworkPolicySpec{},
+				},
+			},
+		},
+		{
+			name:              "reconcile with existing istio-mesh NetworkPolicy",
+			annotations:       map[string]string{},
+			want:              map[string]string{resources.TimeoutAnnotation: "5s", networking.IngressClassAnnotationKey: network.IstioIngressClassName},
+			wantRouteErr:      func(err error) bool { return err == nil },
+			wantSmmr:          true,
+			wantNetworkPolicy: true,
+			extraObjs: []runtime.Object{
+				&networkingv1.NetworkPolicy{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "istio-mesh",
+						Namespace: namespace,
+						Labels:    map[string]string{"maistra.io/owner": "knative-serving-ingress"},
+					},
+					Spec: networkingv1.NetworkPolicySpec{},
+				},
+			},
+		},
+		{
+			name:              "reconcile with existing managed and istio-mesh NetworkPolicies",
+			annotations:       map[string]string{},
+			want:              map[string]string{resources.TimeoutAnnotation: "5s", networking.IngressClassAnnotationKey: network.IstioIngressClassName},
+			wantRouteErr:      func(err error) bool { return err == nil },
+			wantSmmr:          true,
+			wantNetworkPolicy: true,
+			extraObjs: []runtime.Object{
+				&networkingv1.NetworkPolicy{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      resources.NetworkPolicyAllowAllName,
+						Namespace: namespace,
+					},
+					Spec: networkingv1.NetworkPolicySpec{},
+				},
+				&networkingv1.NetworkPolicy{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "istio-mesh",
+						Namespace: namespace,
+						Labels:    map[string]string{"maistra.io/owner": "knative-serving-ingress"},
+					},
+					Spec: networkingv1.NetworkPolicySpec{},
+				},
+			},
+		},
+		{
+			name:              "reconcile with user-added NetworkPolicy",
+			annotations:       map[string]string{},
+			want:              map[string]string{resources.TimeoutAnnotation: "5s", networking.IngressClassAnnotationKey: network.IstioIngressClassName},
+			wantRouteErr:      func(err error) bool { return err == nil },
+			wantSmmr:          true,
+			wantNetworkPolicy: false,
+			extraObjs: []runtime.Object{
+				&networkingv1.NetworkPolicy{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "my-network-policy",
+						Namespace: namespace,
+					},
+					Spec: networkingv1.NetworkPolicySpec{},
+				},
+			},
+		},
+		{
+			name:              "reconcile with existing managed and user-added NetworkPolicies",
+			annotations:       map[string]string{},
+			want:              map[string]string{resources.TimeoutAnnotation: "5s", networking.IngressClassAnnotationKey: network.IstioIngressClassName},
+			wantRouteErr:      func(err error) bool { return err == nil },
+			wantSmmr:          true,
+			wantNetworkPolicy: true,
+			extraObjs: []runtime.Object{
+				&networkingv1.NetworkPolicy{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "my-network-policy",
+						Namespace: namespace,
+					},
+					Spec: networkingv1.NetworkPolicySpec{},
+				},
+				&networkingv1.NetworkPolicy{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      resources.NetworkPolicyAllowAllName,
+						Namespace: namespace,
+					},
+					Spec: networkingv1.NetworkPolicySpec{},
+				},
+			},
 		},
 	}
 
@@ -247,6 +365,9 @@ func TestIngressController(t *testing.T) {
 				},
 			}
 
+			initObjs := []runtime.Object{smmr, ingress, route}
+			initObjs = append(initObjs, test.extraObjs...)
+
 			// Register operator types with the runtime scheme.
 			s := scheme.Scheme
 			s.AddKnownTypes(maistrav1.SchemeGroupVersion, smmr)
@@ -254,7 +375,7 @@ func TestIngressController(t *testing.T) {
 			s.AddKnownTypes(routev1.SchemeGroupVersion, route)
 			s.AddKnownTypes(routev1.SchemeGroupVersion, &routev1.RouteList{})
 			// Create a fake client to mock API calls.
-			cl := fake.NewFakeClient(smmr, ingress, route)
+			cl := fake.NewFakeClient(initObjs...)
 			// Create a Reconcile Ingress object with the scheme and fake client.
 			r := &ReconcileIngress{base: &common.BaseIngressReconciler{Client: cl}, client: cl, scheme: s}
 
@@ -274,16 +395,26 @@ func TestIngressController(t *testing.T) {
 			if err := cl.Get(context.TODO(), types.NamespacedName{Name: smmrName, Namespace: serviceMeshNamespace}, smmr); err != nil {
 				t.Fatalf("failed to get ServiceMeshMemberRole: (%v)", err)
 			}
-			if ingress.GetAnnotations()[networking.IngressClassAnnotationKey] == network.IstioIngressClassName {
+			if test.wantSmmr {
 				assert.Equal(t, []string{namespace}, smmr.Spec.Members)
 			} else {
 				assert.Equal(t, 0, len(smmr.Spec.Members))
 			}
+
+			// Check if NetworkPolicy has been created
+			networkPolicy := &networkingv1.NetworkPolicy{}
+			err := cl.Get(context.TODO(), types.NamespacedName{Name: resources.NetworkPolicyAllowAllName, Namespace: namespace}, networkPolicy)
+			if test.wantNetworkPolicy {
+				assert.Nil(t, err)
+			} else {
+				assert.True(t, errors.IsNotFound(err))
+			}
+
 			// Check if route has been created
 			routes := &routev1.Route{}
-			err := cl.Get(context.TODO(), types.NamespacedName{Name: routeName0, Namespace: serviceMeshNamespace}, routes)
+			err = cl.Get(context.TODO(), types.NamespacedName{Name: routeName0, Namespace: serviceMeshNamespace}, routes)
 
-			assert.True(t, test.wantErr(err))
+			assert.True(t, test.wantRouteErr(err))
 			assert.Equal(t, test.want, routes.ObjectMeta.Annotations)
 		})
 	}

--- a/pkg/controller/resources/network_policy.go
+++ b/pkg/controller/resources/network_policy.go
@@ -3,7 +3,6 @@ package resources
 import (
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	networkingv1alpha1 "knative.dev/serving/pkg/apis/networking/v1alpha1"
 )
 
 const (
@@ -12,11 +11,11 @@ const (
 
 // MakeNetworkPolicyAllowAll creates a Kubernetes NetworkPolicy
 // allowing all traffic into the namespace of a Knative Ingress
-func MakeNetworkPolicyAllowAll(ci networkingv1alpha1.IngressAccessor) *networkingv1.NetworkPolicy {
+func MakeNetworkPolicyAllowAll(ns string) *networkingv1.NetworkPolicy {
 	networkPolicy := &networkingv1.NetworkPolicy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      NetworkPolicyAllowAllName,
-			Namespace: ci.GetNamespace(),
+			Namespace: ns,
 		},
 		Spec: networkingv1.NetworkPolicySpec{
 			PodSelector: metav1.LabelSelector{},

--- a/pkg/controller/resources/network_policy.go
+++ b/pkg/controller/resources/network_policy.go
@@ -1,0 +1,36 @@
+package resources
+
+import (
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	networkingv1alpha1 "knative.dev/serving/pkg/apis/networking/v1alpha1"
+)
+
+const (
+	NetworkPolicyAllowAllName = "knative-serving-allow-all"
+)
+
+// MakeNetworkPolicyAllowAll creates a Kubernetes NetworkPolicy
+// allowing all traffic into the namespace of a Knative Ingress
+func MakeNetworkPolicyAllowAll(ci networkingv1alpha1.IngressAccessor) *networkingv1.NetworkPolicy {
+	networkPolicy := &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      NetworkPolicyAllowAllName,
+			Namespace: ci.GetNamespace(),
+		},
+		Spec: networkingv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{},
+			Ingress: []networkingv1.NetworkPolicyIngressRule{
+				networkingv1.NetworkPolicyIngressRule{},
+			},
+			Egress: []networkingv1.NetworkPolicyEgressRule{
+				networkingv1.NetworkPolicyEgressRule{},
+			},
+			PolicyTypes: []networkingv1.PolicyType{
+				networkingv1.PolicyTypeIngress,
+				networkingv1.PolicyTypeEgress,
+			},
+		},
+	}
+	return networkPolicy
+}


### PR DESCRIPTION
For namespaces we auto-enroll into a ServiceMeshMemberRoll, we'll now
also install a default allow-all ingress and egress NetworkPolicy. We
only do this if we detect there are no other NetworkPolicy objects in
the namespace except those managed by Service Mesh and us.

If there are other NetworkPolicy objects, we assume the user has taken
responsibility for managing NetworkPolicy in this namespace and thus
do not install our allow-all NetworkPolicy.

This is intended to give the user the same level of ingress and egress
after they create a Knative Service (and thus add this namespace to
our SMMR) as they had before.