### PR TITLE
[SRVKS-325] Add TLS route with edge termination

### DIFF
--- a/deploy/release.yaml
+++ b/deploy/release.yaml
@@ -26,6 +26,13 @@ rules:
   verbs:
   - get
 - apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - list
+  - watch
+- apiGroups:
   - apps
   resources:
   - deployments

--- a/pkg/controller/common/reconciler.go
+++ b/pkg/controller/common/reconciler.go
@@ -65,7 +65,7 @@ func (r *BaseIngressReconciler) ReconcileIngress(ctx context.Context, ci network
 		}
 		existingMap := routeMap(existing, selector)
 
-		routes, err := resources.MakeRoutes(ci)
+		routes, err := resources.MakeRoutes(ci, r.Client)
 		if err != nil {
 			logger.Warnf("Failed to generate routes from ingress %v", err)
 			// Returning nil aborts the reconcilation. It will be retriggered once the status of the ingress changes.

--- a/pkg/controller/ingress/ingress_controller_test.go
+++ b/pkg/controller/ingress/ingress_controller_test.go
@@ -183,6 +183,10 @@ func TestRouteMigration(t *testing.T) {
 				Port: &routev1.RoutePort{
 					TargetPort: intstr.FromString("http2"),
 				},
+				TLS: &routev1.TLSConfig{
+					Termination:                   routev1.TLSTerminationEdge,
+					InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyAllow,
+				},
 			},
 		}, {
 			ObjectMeta: metav1.ObjectMeta{
@@ -300,24 +304,6 @@ func TestIngressController(t *testing.T) {
 		{
 			name:              "do not reconcile with disable route annotation",
 			annotations:       map[string]string{resources.DisableRouteAnnotation: ""},
-			want:              nil,
-			wantRouteErr:      errors.IsNotFound,
-			wantSmmr:          true,
-			wantNetworkPolicy: true,
-			deleted:           false,
-		},
-		{
-			name:              "reconcile route with passthrough annotation",
-			annotations:       map[string]string{resources.TLSTerminationAnnotation: "passthrough"},
-			want:              map[string]string{resources.TLSTerminationAnnotation: "passthrough", resources.TimeoutAnnotation: "5s", networking.IngressClassAnnotationKey: network.IstioIngressClassName},
-			wantRouteErr:      func(err error) bool { return err == nil },
-			wantSmmr:          true,
-			wantNetworkPolicy: true,
-			deleted:           false,
-		},
-		{
-			name:              "reconcile route with invalid TLS termination annotation",
-			annotations:       map[string]string{resources.TLSTerminationAnnotation: "edge"},
 			want:              nil,
 			wantRouteErr:      errors.IsNotFound,
 			wantSmmr:          true,

--- a/pkg/controller/ingress/ingress_controller_test.go
+++ b/pkg/controller/ingress/ingress_controller_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/openshift-knative/knative-openshift-ingress/pkg/controller/resources"
 	routev1 "github.com/openshift/api/route/v1"
 	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -36,6 +37,7 @@ const (
 	uid                  = "8a7e9a9d-fbc6-11e9-a88e-0261aff8d6d8"
 	domainName           = name + "." + namespace + ".default.domainName"
 	routeName0           = "route-" + uid + "-336636653035"
+	testSecretName       = "testSecret"
 )
 
 var (
@@ -92,6 +94,13 @@ var (
 					DomainInternal: "cluster-local-gateway." + serviceMeshNamespace + ".svc.cluster.local",
 				}},
 			},
+		},
+	}
+
+	defaultSecret = &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testSecretName,
+			Namespace: namespace,
 		},
 	}
 )
@@ -531,6 +540,15 @@ func TestIngressController(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:              "reconcile route with custom certificate by annotation",
+			annotations:       map[string]string{resources.CertificateAnnotation: testSecretName},
+			want:              map[string]string{resources.CertificateAnnotation: testSecretName, resources.TimeoutAnnotation: "5s", networking.IngressClassAnnotationKey: network.IstioIngressClassName},
+			wantRouteErr:      func(err error) bool { return err == nil },
+			wantSmmr:          true,
+			wantNetworkPolicy: true,
+			deleted:           false,
+		},
 	}
 
 	for _, test := range tests {
@@ -560,7 +578,7 @@ func TestIngressController(t *testing.T) {
 				},
 			}
 
-			initObjs := []runtime.Object{smmr, ingress, route}
+			initObjs := []runtime.Object{smmr, ingress, route, defaultSecret}
 			initObjs = append(initObjs, test.extraObjs...)
 
 			// Register operator types with the runtime scheme.

--- a/pkg/controller/resources/route.go
+++ b/pkg/controller/resources/route.go
@@ -18,20 +18,11 @@ import (
 const (
 	TimeoutAnnotation      = "haproxy.router.openshift.io/timeout"
 	DisableRouteAnnotation = "serving.knative.openshift.io/disableRoute"
-	TerminationAnnotation  = "serving.knative.openshift.io/tlsMode"
-
-	// TLSTerminationAnnotation is an annotation to configure routes.spec.tls.termination
-	TLSTerminationAnnotation = "serving.knative.openshift.io/tlsTermination"
 )
 
-var (
-	// ErrNotSupportedTLSTermination is an error when unsupported TLS termination is configured via annotation.
-	ErrNotSupportedTLSTermination = errors.New("not supported tls termination is specified, only 'passthrough' is valid")
-
-	// ErrNoValidLoadbalancerDomain indicates that the current ingress does not have a DomainInternal field, or
-	// said field does not contain a value we can work with.
-	ErrNoValidLoadbalancerDomain = errors.New("unable to find ClusterIngress LoadBalancer with DomainInternal set")
-)
+// ErrNoValidLoadbalancerDomain indicates that the current ingress does not have a DomainInternal field, or
+// said field does not contain a value we can work with.
+var ErrNoValidLoadbalancerDomain = errors.New("unable to find ClusterIngress LoadBalancer with DomainInternal set")
 
 // MakeRoutes creates OpenShift Routes from a Knative Ingress
 func MakeRoutes(ci networkingv1alpha1.IngressAccessor) ([]*routev1.Route, error) {
@@ -145,16 +136,11 @@ func makeRoute(ci networkingv1alpha1.IngressAccessor, host string, rule networki
 				Kind: "Service",
 				Name: serviceName,
 			},
+			TLS: &routev1.TLSConfig{
+				Termination:                   routev1.TLSTerminationEdge,
+				InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyAllow,
+			},
 		},
-	}
-	if terminationType, ok := annotations[TLSTerminationAnnotation]; ok {
-		switch strings.ToLower(terminationType) {
-		case "passthrough":
-			route.Spec.TLS = &routev1.TLSConfig{Termination: routev1.TLSTerminationPassthrough}
-			route.Spec.Port = &routev1.RoutePort{TargetPort: intstr.FromString("https")}
-		default:
-			return nil, ErrNotSupportedTLSTermination
-		}
 	}
 	return route, nil
 }

--- a/pkg/controller/resources/route.go
+++ b/pkg/controller/resources/route.go
@@ -152,13 +152,12 @@ func makeRoute(ci networkingv1alpha1.IngressAccessor, client client.Client, host
 			TLS: &routev1.TLSConfig{
 				Certificate:                   string(secret.Data["tls.crt"]),
 				Key:                           string(secret.Data["tls.key"]),
-				CACertificate:                 string(secret.Data["caCertificate"]),
+				CACertificate:                 string(secret.Data["ca.crt"]),
 				Termination:                   routev1.TLSTerminationEdge,
 				InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyAllow,
 			},
 		},
 	}
-
 	return route, nil
 }
 

--- a/pkg/controller/resources/route_test.go
+++ b/pkg/controller/resources/route_test.go
@@ -13,6 +13,8 @@ import (
 	"knative.dev/serving/pkg/apis/networking"
 	networkingv1alpha1 "knative.dev/serving/pkg/apis/networking/v1alpha1"
 	"knative.dev/serving/pkg/apis/serving"
+
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 const (
@@ -242,9 +244,11 @@ func TestMakeRoute(t *testing.T) {
 		},
 	}
 
+	fakeClient := fake.NewFakeClient()
+
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			routes, err := MakeRoutes(test.ingress)
+			routes, err := MakeRoutes(test.ingress, fakeClient)
 			if test.want != nil && !cmp.Equal(routes, test.want) {
 				t.Errorf("got = %v, want: %v, diff: %s", routes, test.want, cmp.Diff(routes, test.want))
 			}

--- a/pkg/controller/resources/route_test.go
+++ b/pkg/controller/resources/route_test.go
@@ -77,6 +77,10 @@ func TestMakeRoute(t *testing.T) {
 					Port: &routev1.RoutePort{
 						TargetPort: intstr.FromString("http2"),
 					},
+					TLS: &routev1.TLSConfig{
+						Termination:                   routev1.TLSTerminationEdge,
+						InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyAllow,
+					},
 				},
 			}},
 		},
@@ -122,6 +126,10 @@ func TestMakeRoute(t *testing.T) {
 					Port: &routev1.RoutePort{
 						TargetPort: intstr.FromString("http2"),
 					},
+					TLS: &routev1.TLSConfig{
+						Termination:                   routev1.TLSTerminationEdge,
+						InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyAllow,
+					},
 				},
 			}},
 		},
@@ -154,6 +162,10 @@ func TestMakeRoute(t *testing.T) {
 					Port: &routev1.RoutePort{
 						TargetPort: intstr.FromString("http2"),
 					},
+					TLS: &routev1.TLSConfig{
+						Termination:                   routev1.TLSTerminationEdge,
+						InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyAllow,
+					},
 				},
 			}, {
 				ObjectMeta: metav1.ObjectMeta{
@@ -177,6 +189,10 @@ func TestMakeRoute(t *testing.T) {
 					},
 					Port: &routev1.RoutePort{
 						TargetPort: intstr.FromString("http2"),
+					},
+					TLS: &routev1.TLSConfig{
+						Termination:                   routev1.TLSTerminationEdge,
+						InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyAllow,
 					},
 				},
 			}},
@@ -210,6 +226,10 @@ func TestMakeRoute(t *testing.T) {
 					Port: &routev1.RoutePort{
 						TargetPort: intstr.FromString("http2"),
 					},
+					TLS: &routev1.TLSConfig{
+						Termination:                   routev1.TLSTerminationEdge,
+						InsecureEdgeTerminationPolicy: routev1.InsecureEdgeTerminationPolicyAllow,
+					},
 				},
 			}},
 		},
@@ -219,48 +239,6 @@ func TestMakeRoute(t *testing.T) {
 				rule(withHosts([]string{localDomain, externalDomain}))),
 			),
 			wantErr: ErrNoValidLoadbalancerDomain,
-		},
-		{
-			name: "tls: passthrough termination",
-			ingress: ingress(withTLSTerminationAnnotation("passthrough"), withRules(
-				rule(withHosts([]string{localDomain, externalDomain}))),
-			),
-			want: []*routev1.Route{{
-				ObjectMeta: metav1.ObjectMeta{
-					OwnerReferences: []metav1.OwnerReference{ownerRef},
-					Labels: map[string]string{
-						networking.IngressLabelKey:     "ingress",
-						serving.RouteLabelKey:          "route1",
-						serving.RouteNamespaceLabelKey: "default",
-					},
-					Annotations: map[string]string{
-						TimeoutAnnotation:        "600s",
-						TLSTerminationAnnotation: "passthrough",
-					},
-					Namespace: lbNamespace,
-					Name:      routeName0,
-				},
-				Spec: routev1.RouteSpec{
-					Host: externalDomain,
-					To: routev1.RouteTargetReference{
-						Kind: "Service",
-						Name: lbService,
-					},
-					Port: &routev1.RoutePort{
-						TargetPort: intstr.FromString("https"),
-					},
-					TLS: &routev1.TLSConfig{
-						Termination: routev1.TLSTerminationPassthrough,
-					},
-				},
-			}},
-		},
-		{
-			name: "tls: unsupported termination",
-			ingress: ingress(withTLSTerminationAnnotation("edge"), withRules(
-				rule(withHosts([]string{localDomain, externalDomain}))),
-			),
-			wantErr: ErrNotSupportedTLSTermination,
 		},
 	}
 
@@ -337,17 +315,6 @@ func withDisabledAnnotation(ing networkingv1alpha1.IngressAccessor) {
 	}
 	annos[DisableRouteAnnotation] = ""
 	ing.SetAnnotations(annos)
-}
-
-func withTLSTerminationAnnotation(value string) ingressOption {
-	return func(ing networkingv1alpha1.IngressAccessor) {
-		annos := ing.GetAnnotations()
-		if annos == nil {
-			annos = map[string]string{}
-		}
-		annos[TLSTerminationAnnotation] = value
-		ing.SetAnnotations(annos)
-	}
 }
 
 func withLocalVisibility(ing networkingv1alpha1.IngressAccessor) {


### PR DESCRIPTION
This patch changes to:
- Retire passthrough TLS termination due to SRVKS-200.
- Enable TLS with edge termination and non-secure route (HTTP) is available __by default__. Users can use TLS with [OpenShift Ingress's default cert](https://docs.openshift.com/container-platform/4.2/authentication/certificates/replacing-default-ingress-certificate.html).
- Support custom certs via Secret by using `serving.knative.openshift.io/certificate` annotation. k-o-i extracts the secret and [adds certs to each Route](https://docs.openshift.com/container-platform/4.2/networking/routes/secured-routes.html#nw-ingress-creating-an-edge-route-with-a-custom-certificate_secured-routes).

This patch does not include:
- `oc get ksvc` command still prints URL with `http`, though `https` is available.
- gRPC/HTTP2 still does not work as OpenShift Route does not support it yet.