### PR TITLE
Remove obsolete routes in other namespaces even if the names match.

### DIFF
--- a/pkg/controller/common/reconciler.go
+++ b/pkg/controller/common/reconciler.go
@@ -76,7 +76,7 @@ func (r *BaseIngressReconciler) ReconcileIngress(ctx context.Context, ci network
 			if err := r.reconcileRoute(ctx, ci, route); err != nil {
 				return fmt.Errorf("failed to create route for host %s: %v", route.Spec.Host, err)
 			}
-			delete(existingMap, route.Name)
+			delete(existingMap, route.Namespace+"/"+route.Name)
 		}
 		// If routes remains in existingMap, it must be obsoleted routes. Clean them up.
 		for _, rt := range existingMap {
@@ -222,7 +222,7 @@ func routeMap(routes routev1.RouteList, selector map[string]string) map[string]r
 		// and we can't bump the osdk version quickly. ref:
 		// https://github.com/openshift-knative/knative-openshift-ingress/pull/24#discussion_r341804021
 		if routeLabelFilter(route, selector) {
-			mp[route.Name] = route
+			mp[route.Namespace+"/"+route.Name] = route
 		}
 	}
 	return mp

--- a/pkg/controller/ingress/ingress_controller_test.go
+++ b/pkg/controller/ingress/ingress_controller_test.go
@@ -155,6 +155,13 @@ func TestRouteMigration(t *testing.T) {
 			Spec: routev1.RouteSpec{Host: domainName},
 		}, {
 			ObjectMeta: metav1.ObjectMeta{
+				Name:      routeName0,
+				Namespace: "istio-system",
+				Labels:    map[string]string{networking.IngressLabelKey: name, serving.RouteLabelKey: name, serving.RouteNamespaceLabelKey: namespace},
+			},
+			Spec: routev1.RouteSpec{Host: domainName},
+		}, {
+			ObjectMeta: metav1.ObjectMeta{
 				Name:   "no-remove-missing-label",
 				Labels: map[string]string{networking.IngressLabelKey: name, serving.RouteLabelKey: name},
 			},


### PR DESCRIPTION
Today, if two routes in different namespaces have the same name and one of them is not obsolete, the other is not obsoleted as well. That breaks upgrade cases where the new routes are already created in an old-outdated namespaces and are then to be replaced in a new namespace.